### PR TITLE
feat: support incremental syncs using search endpoints

### DIFF
--- a/tap_hubspot/streams.py
+++ b/tap_hubspot/streams.py
@@ -35,8 +35,9 @@ class ContactStream(DynamicHubspotStream):
 
     name = "contacts"
     path = "/objects/contacts"
+    incremental_path = "/objects/contacts/search"
     primary_keys = ["id"]
-    replication_key = "updatedAt"
+    replication_key = "lastmodifieddate"
     replication_method = "INCREMENTAL"
     records_jsonpath = "$[results][*]"  # Or override `parse_response`.
 
@@ -66,8 +67,6 @@ class UsersStream(HubspotStream):
     name = "users"
     path = "/users"
     primary_keys = ["id"]
-    replication_key = "id"
-    replication_method = "INCREMENTAL"
     records_jsonpath = "$[results][*]"  # Or override `parse_response`.
 
     schema = PropertiesList(
@@ -104,8 +103,6 @@ class OwnersStream(HubspotStream):
     name = "owners"
     path = "/owners"
     primary_keys = ["id"]
-    replication_key = "updatedAt"
-    replication_method = "INCREMENTAL"
     records_jsonpath = "$[results][*]"  # Or override `parse_response`.
 
     schema = PropertiesList(
@@ -145,8 +142,6 @@ class TicketPipelineStream(HubspotStream):
     name = "ticket_pipelines"
     path = "/pipelines/tickets"
     primary_keys = ["createdAt"]
-    replication_key = "createdAt"
-    replication_method = "INCREMENTAL"
     records_jsonpath = "$[results][*]"  # Or override `parse_response`.
 
     schema = PropertiesList(
@@ -207,8 +202,6 @@ class DealPipelineStream(HubspotStream):
     name = "deal_pipelines"
     path = "/pipelines/deals"
     primary_keys = ["createdAt"]
-    replication_key = "createdAt"
-    replication_method = "INCREMENTAL"
     records_jsonpath = "$[results][*]"  # Or override `parse_response`.
 
     schema = PropertiesList(
@@ -269,8 +262,6 @@ class EmailSubscriptionStream(HubspotStream):
     name = "email_subscriptions"
     path = "/subscriptions"
     primary_keys = ["id"]
-    replication_key = "id"
-    replication_method = "INCREMENTAL"
     records_jsonpath = "$[subscriptionDefinitions][*]"  # Or override `parse_response`.
 
     schema = PropertiesList(
@@ -312,8 +303,6 @@ class PropertyTicketStream(HubspotStream):
     name = "property_tickets"
     path = "/properties/tickets"
     primary_keys = ["label"]
-    replication_key = "updatedAt"
-    replication_method = "INCREMENTAL"
     records_jsonpath = "$[results][*]"  # Or override `parse_response`.
 
     schema = PropertiesList(
@@ -382,8 +371,6 @@ class PropertyDealStream(HubspotStream):
     name = "property_deals"
     path = "/properties/deals"
     primary_keys = ["label"]
-    replication_key = "updatedAt"
-    replication_method = "INCREMENTAL"
     records_jsonpath = "$[results][*]"  # Or override `parse_response`.
 
     schema = PropertiesList(
@@ -453,8 +440,6 @@ class PropertyContactStream(HubspotStream):
     name = "property_contacts"
     path = "/properties/contacts"
     primary_keys = ["label"]
-    replication_key = "updatedAt"
-    replication_method = "INCREMENTAL"
     records_jsonpath = "$[results][*]"  # Or override `parse_response`.
 
     schema = PropertiesList(
@@ -523,8 +508,6 @@ class PropertyCompanyStream(HubspotStream):
     name = "property_companies"
     path = "/properties/company"
     primary_keys = ["label"]
-    replication_key = "updatedAt"
-    replication_method = "INCREMENTAL"
     records_jsonpath = "$[results][*]"  # Or override `parse_response`.
 
     schema = PropertiesList(
@@ -593,8 +576,6 @@ class PropertyProductStream(HubspotStream):
     name = "property_products"
     path = "/properties/product"
     primary_keys = ["label"]
-    replication_key = "updatedAt"
-    replication_method = "INCREMENTAL"
     records_jsonpath = "$[results][*]"  # Or override `parse_response`.
 
     schema = PropertiesList(
@@ -663,8 +644,6 @@ class PropertyLineItemStream(HubspotStream):
     name = "property_line_items"
     path = "/properties/line_item"
     primary_keys = ["label"]
-    replication_key = "updatedAt"
-    replication_method = "INCREMENTAL"
     records_jsonpath = "$[results][*]"  # Or override `parse_response`.
 
     schema = PropertiesList(
@@ -733,8 +712,6 @@ class PropertyEmailStream(HubspotStream):
     name = "property_emails"
     path = "/properties/email"
     primary_keys = ["label"]
-    replication_key = "updatedAt"
-    replication_method = "INCREMENTAL"
     records_jsonpath = "$[results][*]"  # Or override `parse_response`.
 
     schema = PropertiesList(
@@ -803,8 +780,6 @@ class PropertyPostalMailStream(HubspotStream):
     name = "property_postal_mails"
     path = "/properties/postal_mail"
     primary_keys = ["label"]
-    replication_key = "updatedAt"
-    replication_method = "INCREMENTAL"
     records_jsonpath = "$[results][*]"  # Or override `parse_response`.
 
     schema = PropertiesList(
@@ -873,8 +848,6 @@ class PropertyCallStream(HubspotStream):
     name = "property_calls"
     path = "/properties/call"
     primary_keys = ["label"]
-    replication_key = "updatedAt"
-    replication_method = "INCREMENTAL"
     records_jsonpath = "$[results][*]"  # Or override `parse_response`.
 
     schema = PropertiesList(
@@ -943,8 +916,6 @@ class PropertyMeetingStream(HubspotStream):
     name = "property_meetings"
     path = "/properties/meeting"
     primary_keys = ["label"]
-    replication_key = "updatedAt"
-    replication_method = "INCREMENTAL"
     records_jsonpath = "$[results][*]"  # Or override `parse_response`.
 
     schema = PropertiesList(
@@ -1013,8 +984,6 @@ class PropertyTaskStream(HubspotStream):
     name = "property_tasks"
     path = "/properties/task"
     primary_keys = ["label"]
-    replication_key = "updatedAt"
-    replication_method = "INCREMENTAL"
     records_jsonpath = "$[results][*]"  # Or override `parse_response`.
 
     schema = PropertiesList(
@@ -1083,8 +1052,6 @@ class PropertyCommunicationStream(HubspotStream):
     name = "property_communications"
     path = "/properties/communication"
     primary_keys = ["label"]
-    replication_key = "updatedAt"
-    replication_method = "INCREMENTAL"
     records_jsonpath = "$[results][*]"  # Or override `parse_response`.
 
     schema = PropertiesList(
@@ -1153,8 +1120,6 @@ class PropertyNotesStream(HubspotStream):
     name = "properties"
     path = "/properties/notes"
     primary_keys = ["label"]
-    replication_key = "updatedAt"
-    replication_method = "INCREMENTAL"
     records_jsonpath = "$[results][*]"  # Or override `parse_response`.
 
     schema = PropertiesList(
@@ -1261,8 +1226,9 @@ class CompanyStream(DynamicHubspotStream):
 
     name = "companies"
     path = "/objects/companies"
+    incremental_path = "/objects/companies/search"
     primary_keys = ["id"]
-    replication_key = "updatedAt"
+    replication_key = "lastmodifieddate"
     replication_method = "INCREMENTAL"
     records_jsonpath = "$[results][*]"  # Or override `parse_response`.
 
@@ -1290,9 +1256,10 @@ class DealStream(DynamicHubspotStream):
 
     name = "deals"
     path = "/objects/deals"
+    incremental_path = "/objects/deals/search"
     primary_keys = ["id"]
     replication_key = "updatedAt"
-    replication_method = "INCREMENTAL"
+    replication_method = "lastmodifieddate"
     records_jsonpath = "$[results][*]"  # Or override `parse_response`.
 
     @property
@@ -1320,8 +1287,6 @@ class FeedbackSubmissionsStream(HubspotStream):
     name = "feedback_submissions"
     path = "/objects/feedback_submissions"
     primary_keys = ["id"]
-    replication_key = "updatedAt"
-    replication_method = "INCREMENTAL"
     records_jsonpath = "$[results][*]"  # Or override `parse_response`.
 
     schema = PropertiesList(
@@ -1369,8 +1334,6 @@ class LineItemStream(HubspotStream):
     name = "line_items"
     path = "/objects/line_items"
     primary_keys = ["id"]
-    replication_key = "updatedAt"
-    replication_method = "INCREMENTAL"
     records_jsonpath = "$[results][*]"  # Or override `parse_response`.
 
     schema = PropertiesList(
@@ -1418,8 +1381,6 @@ class ProductStream(HubspotStream):
     name = "products"
     path = "/objects/products"
     primary_keys = ["id"]
-    replication_key = "updatedAt"
-    replication_method = "INCREMENTAL"
     records_jsonpath = "$[results][*]"  # Or override `parse_response`.
 
     schema = PropertiesList(
@@ -1467,8 +1428,6 @@ class TicketStream(HubspotStream):
     name = "tickets"
     path = "/objects/tickets"
     primary_keys = ["id"]
-    replication_key = "updatedAt"
-    replication_method = "INCREMENTAL"
     records_jsonpath = "$[results][*]"  # Or override `parse_response`.
 
     schema = PropertiesList(
@@ -1515,8 +1474,6 @@ class QuoteStream(HubspotStream):
     name = "quotes"
     path = "/objects/quotes"
     primary_keys = ["id"]
-    replication_key = "updatedAt"
-    replication_method = "INCREMENTAL"
     records_jsonpath = "$[results][*]"  # Or override `parse_response`.
 
     schema = PropertiesList(
@@ -1564,8 +1521,6 @@ class GoalStream(HubspotStream):
     name = "goals"
     path = "/objects/goal_targets"
     primary_keys = ["id"]
-    replication_key = "updatedAt"
-    replication_method = "INCREMENTAL"
     records_jsonpath = "$[results][*]"  # Or override `parse_response`.
 
     schema = PropertiesList(
@@ -1611,8 +1566,9 @@ class CallStream(DynamicHubspotStream):
 
     name = "calls"
     path = "/objects/calls"
+    incremental_path = "/objects/calls/search"
     primary_keys = ["id"]
-    replication_key = "updatedAt"
+    replication_key = "lastmodifieddate"
     replication_method = "INCREMENTAL"
     records_jsonpath = "$[results][*]"  # Or override `parse_response`.
 
@@ -1639,9 +1595,10 @@ class CommunicationStream(DynamicHubspotStream):
     """
 
     name = "communications"
-    path = "/objects/Communications"
+    path = "/objects/communications"
+    incremental_path = "/objects/communications/search"
     primary_keys = ["id"]
-    replication_key = "updatedAt"
+    replication_key = "lastmodifieddate"
     replication_method = "INCREMENTAL"
     records_jsonpath = "$[results][*]"  # Or override `parse_response`.
 
@@ -1670,8 +1627,6 @@ class EmailStream(HubspotStream):
     name = "emails"
     path = "/objects/emails"
     primary_keys = ["id"]
-    replication_key = "updatedAt"
-    replication_method = "INCREMENTAL"
     records_jsonpath = "$[results][*]"  # Or override `parse_response`.
 
     schema = PropertiesList(
@@ -1724,8 +1679,9 @@ class MeetingStream(DynamicHubspotStream):
 
     name = "meetings"
     path = "/objects/meetings"
+    incremental_path = "/objects/meetings/search"
     primary_keys = ["id"]
-    replication_key = "updatedAt"
+    replication_key = "lastmodifieddate"
     replication_method = "INCREMENTAL"
     records_jsonpath = "$[results][*]"  # Or override `parse_response`.
 
@@ -1753,8 +1709,9 @@ class NoteStream(DynamicHubspotStream):
 
     name = "notes"
     path = "/objects/notes"
+    incremental_path = "/objects/notes/search"
     primary_keys = ["id"]
-    replication_key = "updatedAt"
+    replication_key = "lastmodifieddate"
     replication_method = "INCREMENTAL"
     records_jsonpath = "$[results][*]"  # Or override `parse_response`.
 
@@ -1782,8 +1739,9 @@ class PostalMailStream(DynamicHubspotStream):
 
     name = "postal_mail"
     path = "/objects/postal_mail"
+    incremental_path = "/objects/postal_mail/search"
     primary_keys = ["id"]
-    replication_key = "updatedAt"
+    replication_key = "lastmodifieddate"
     replication_method = "INCREMENTAL"
     records_jsonpath = "$[results][*]"  # Or override `parse_response`.
 
@@ -1811,8 +1769,9 @@ class TaskStream(DynamicHubspotStream):
 
     name = "tasks"
     path = "/objects/tasks"
+    incremental_path = "/objects/tasks/search"
     primary_keys = ["id"]
-    replication_key = "updatedAt"
+    replication_key = "lastmodifieddate"
     replication_method = "INCREMENTAL"
     records_jsonpath = "$[results][*]"  # Or override `parse_response`.
 


### PR DESCRIPTION
- Remove incremental `replication_method` and key on streams that dont actually attempt incremental syncs
- Add a new search endpoint property thats used when running incrementally. The hubspot API has a list endpoint (GET) and a search endpoint (POST) that are separate. So on the first run it will use the list endpoint then if running incrementally it will use the search endpoint and filter with the state.

Notes:
- I dont know if theres an advantage to using the list endpoint. We might be better off using only the search endpoint.
- I only activated incremental for a few streams but it should work for any that use the crm endpoints and that have a `lastmodifieddate` field.

Workarounds and bugs:
- The SDK seems to remove some precision from the replicate date. I noticed it rounded up in my test case so the >= filter didnt find any new records. To handle this I subtract a1 second before using the bookmark as a filter.
- The hubspot API is very weird about timestamps and timezones. The docs claim that everything is in UTC but from testing I know that its not. If I receive `2024-01-03T15:37:16.507Z` as the last modified date of a contact (confirmed in UTC), then use that (in epoch ts form) as the request filter with >= logic I dont get any data back. If I subtract exactly 5 hrs from that "UTC" timestamp then I get the record I'm looking for. This makes me think that its taking my UTC ts filter value, adding 5 hrs to it to convert it to UTC using my default account TZ, then searching in its database using that incorrect value. Two solutions I can think of are:
  - Accept a timezone config and remove the appropriate amount to convert back to UTC again so their bug reverts it to the right value.
  - Use a lookback range like 24 hrs and manually filter in a post process step.

@edgarrmondragon let me know if you have any thought on all this