### PR TITLE
set `is_sorted` to true in `DynamicIncrementalHubspotStream`

### DIFF
--- a/tap_hubspot/client.py
+++ b/tap_hubspot/client.py
@@ -192,6 +192,8 @@ class DynamicHubspotStream(HubspotStream):
 class DynamicIncrementalHubspotStream(DynamicHubspotStream):
     """DynamicIncrementalHubspotStream."""
 
+    is_sorted = True
+
     def __init__(self, *args: t.Any, **kwargs: t.Any) -> None:  # noqa: D107
         super().__init__(*args, **kwargs)
 


### PR DESCRIPTION
the results are sorted through the incremental key, so this can be set to true.