### PR TITLE
docs: correct and complete required stream scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,24 +87,30 @@ A Hubspot access token is required to make API requests. (See [Hubspot API](http
 
 The following scopes need to be added to your access token to access the following endpoints:
 
-- Contacts: `crm.schemas.contacts.read` or `crm.objects.contacts.read`
-- Users: `settings.users.read`
-- Teams: `settings.users.teams.read`
-- Ticket Pipeline: `media_bridge.read` or `crm.schemas.custom.read` or `timeline` or `tickets` or `e-commerce` or `crm.objects.goals.read`
-- Deal Pipeline: `media_bridge.read` or `crm.schemas.custom.read` or `timeline` or `tickets` or `e-commerce` or `crm.objects.goals.read`
-- Properties: All of `Tickets`, `crm.objects.deals.read`, `sales-email-read`, `crm.objects.contacts.read`, `crm.objects.companies.read`, `e-commerce`, `crm.objects.quotes.read`
-- Owners: `crm.objects.owners.read`
+- Contacts: `crm.objects.contacts.read`
 - Companies: `crm.objects.companies.read`
 - Deals: `crm.objects.deals.read`
-- Leads: `crm.objects.leads.read` or `crm.schemas.leads.read`
-- Feedback Submissions: `crm.objects.contacts.read`
+- Leads: `crm.objects.leads.read`
+- Owners: `crm.objects.owners.read`
+- Users: `settings.users.read`
+- Teams: `settings.users.teams.read`
+- Feedback Submissions: `crm.objects.feedback_submissions.read`
+- Calls: `crm.objects.calls.read`
+- Communications: `crm.objects.communications.read`
+- Emails: `sales-email-read`
+- Meetings: `crm.objects.meetings.read`
+- Notes: `crm.objects.notes.read`
+- Postal Mail: `crm.objects.postal_mail.read`
+- Tasks: `crm.objects.tasks.read`
 - Line Items: `e-commerce`
 - Products: `e-commerce`
 - Tickets: `tickets`
-- Quotes: `crm.objects.quotes.read` or `crm.schemas.quotes.read`
-- Goals: `crm.objects.goals.read`
-- Emails: `sales-email-read`
+- Ticket Pipelines: `tickets`
+- Deal Pipelines: `crm.objects.deals.read`
+- Quotes: `crm.objects.quotes.read`
+- Goal Targets: `crm.objects.goals.read`
 - Email Subscriptions: `content`
+- Properties: same scopes as the corresponding object type
 - Custom Objects: `crm.objects.custom.read` and `crm.schemas.custom.read` (HubSpot Enterprise only)
 
 For more info on the streams and permissions, check the [Hubspot API Documentation](https://developers.hubspot.com/docs/api/overview).

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ The following scopes need to be added to your access token to access the followi
 - Quotes: `crm.objects.quotes.read` or `crm.schemas.quotes.read`
 - Goals: `crm.objects.goals.read`
 - Emails: `sales-email-read`
+- Email Subscriptions: `content`
 - Custom Objects: `crm.objects.custom.read` and `crm.schemas.custom.read` (HubSpot Enterprise only)
 
 For more info on the streams and permissions, check the [Hubspot API Documentation](https://developers.hubspot.com/docs/api/overview).


### PR DESCRIPTION
## Summary

Fixes multiple errors and gaps in the Permissions section of the README. Scopes were derived from the actual API endpoints in `streams.py` rather than guessed.

## Changes

| Stream | Old | Correct |
|--------|-----|---------|
| `feedback_submissions` | `crm.objects.contacts.read` ❌ | `crm.objects.feedback_submissions.read` |
| `calls` | missing ❌ | `crm.objects.calls.read` |
| `communications` | missing ❌ | `crm.objects.communications.read` |
| `meetings` | missing ❌ | `crm.objects.meetings.read` |
| `notes` | missing ❌ | `crm.objects.notes.read` |
| `postal_mail` | missing ❌ | `crm.objects.postal_mail.read` |
| `tasks` | missing ❌ | `crm.objects.tasks.read` |
| `email_subscriptions` | missing ❌ | `content` |
| `ticket_pipelines` | vague 6-item OR list | `tickets` |
| `deal_pipelines` | vague 6-item OR list | `crm.objects.deals.read` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)