### PR TITLE
fix: Incorrect primary keys for properties streams

### DIFF
--- a/tap_hubspot/client.py
+++ b/tap_hubspot/client.py
@@ -170,7 +170,7 @@ class PropertyStream(HubspotStream):
         th.Property("hubspot_object", th.StringType),
     ).to_dict()
 
-    primary_keys = ("label",)
+    primary_keys = ("name",)
     records_jsonpath = "$[results][*]"
 
     @property


### PR DESCRIPTION
`name` is the correct property to reference in the primary keys configuration. `label` is not guaranteed to be unique and could be updated, resulting in duplicate data downstream.